### PR TITLE
fix: correct 'Helth' typo to 'Health' in game.cpp

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -350,7 +350,7 @@ void Game::renderUI() {
     
     int y = MAP_HEIGHT + 2;
     std::cout << "\033[" << y << ";1H";
-    std::cout << "Helth: " << m_player->health << "/" << m_player->maxHealth;
+    std::cout << "Health: " << m_player->health << "/" << m_player->maxHealth;
     std::cout << "  Level: " << m_player->level;
     std::cout << "  Gold: " << m_player->gold;
     std::cout << "  Dungeon: " << m_player->dungeonLevel;


### PR DESCRIPTION
Fixed typo in player status bar display: 'Helth' → 'Health'