### PR TITLE
fix: Change 'Helth' to 'Health' in game UI

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -350,7 +350,7 @@ void Game::renderUI() {
     
     int y = MAP_HEIGHT + 2;
     std::cout << "\033[" << y << ";1H";
-    std::cout << "Helth: " << m_player->health << "/" << m_player->maxHealth;
+    std::cout << "Health: " << m_player->health << "/" << m_player->maxHealth;
     std::cout << "  Level: " << m_player->level;
     std::cout << "  Gold: " << m_player->gold;
     std::cout << "  Dungeon: " << m_player->dungeonLevel;


### PR DESCRIPTION
## Description

Fixes #1 - Game UI displays 'Helth' instead of 'Health'

**Problem:**
- The game status bar renders 'Helth' instead of 'Health'

**Solution:**
- Changed 'Helth' to 'Health' in src/game.cpp

## Changes

- Modified: src/game.cpp

## Testing

- Verified the change is correct

---

Checklist:

- [x] I have read and followed the contribution guidelines
- [x] I have tested these changes locally
- [x] My PR targets the main branch

Closes #1